### PR TITLE
Support Git Worktree

### DIFF
--- a/util/git.go
+++ b/util/git.go
@@ -2,8 +2,6 @@ package util
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"regexp"
 
 	"github.com/go-git/go-git/v5"
@@ -16,17 +14,10 @@ type SSHHost struct {
 }
 
 func GetHostFromRemoteName(n string) (*SSHHost, error) {
-	wd, err := os.Getwd()
-	if err != nil {
-		return nil, err
+	options := &git.PlainOpenOptions{
+		DetectDotGit: true,
 	}
-
-	gitDir, err := findGitBase(wd)
-	if err != nil {
-		return nil, err
-	}
-
-	repo, err := git.PlainOpen(gitDir)
+	repo, err := git.PlainOpenWithOptions(".", options)
 	if err != nil {
 		return nil, err
 	}
@@ -71,15 +62,4 @@ func parseGitURL(u string) *SSHHost {
 		Host: host,
 		Port: port,
 	}
-}
-
-func findGitBase(p string) (string, error) {
-	if p == "/" {
-		return "", fmt.Errorf("not a git repository")
-	}
-	if fm, err := os.Stat(p + "/.git"); err == nil && fm.IsDir() {
-		return p, nil
-	}
-	ret, err := findGitBase(filepath.Dir(p))
-	return ret, err
 }


### PR DESCRIPTION
First of all, thank you for this tool, it's exactly what I was looking for

Unfortunately, I'm stuck on a specific case

I have my dotfiles with my nixos configuration for my main machine
Which are symlinked to `/etc/nixos`

But I also work / test the configuration of another machine
I use [`git worktree`](https://git-scm.com/docs/git-worktree) to have one repository but several work trees

Which seems not to be supported, can you add support for separate working tree, please?

---

From this separate working tree :

When i do `pushnix deploy pi3bw` i get
> not a git repository


I tried to hack the code, but I never wrote any Go program

I found that the Go Git library already seems to have the function to detect the Git directory :
* https://pkg.go.dev/github.com/go-git/go-git/v5@v5.1.0#PlainOpenWithOptions
* https://pkg.go.dev/github.com/go-git/go-git/v5@v5.1.0#PlainOpenOptions

So I used the library to detect the Git directory, but `pushnix deploy pi3bw` does that:
> remote not found

I'm stuck at this point

---

Here is a simplified version of [my setup](https://gitlab.com/pinage404/dotfiles)
```sh
cd /tmp

# dotfiles with my nixos configuration for my main machine
mkdir dotfiles
cd dotfiles
git init
git commit --allow-empty --message "initial commit"
# symlink to /etc/nixos
sudo mv /etc/nixos /etc/nixos.backup
sudo ln -s $(realpath .) /etc/nixos

# the remote used by pushnix
git remote add pi3bw pi@pi3bw.local:dotfiles

# separate working tree for the other machine
git worktree add ../dotfiles_testing
```

Current behavior :
```sh
cd /tmp

cd dotfiles
# using pushnix from here works as expected
pushnix push pi3bw
# => Pushing configuration to remote pi3bw...
# Everything up-to-date

cd ../dotfiles_testing
# with the current's version
pushnix deploy pi3bw
# not a git repository

pushnix deploy pi3bw
# with my hacked's version
# remote not found
```